### PR TITLE
Updating SPDX License Identifier for GPL 2.0-or-later

### DIFF
--- a/kernel/sel4/toplevels/sel4zsipos/include/litex.h
+++ b/kernel/sel4/toplevels/sel4zsipos/include/litex.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #ifndef _LINUX_LITEX_H
 #define _LINUX_LITEX_H
 


### PR DESCRIPTION
SPDX has updated their license identifiers, and the identifier for the GPL 2.0 is now either "GPL-2.0-only" or "GPL-2.0-or-later".